### PR TITLE
do a git clean in the checkout phase

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 echo "[Run Docker Compose Plugin] - Skipping git checkout"
+
+git clean -ffxdq


### PR DESCRIPTION
Ensures that the working directory starts off in a clean state.

Was seeing artifacts in `/artifacts` hanging around from previous builds.