### PR TITLE
Add support for outputting docker-compose logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ steps:
         build: true
 ```
 
+### `logs` (optional)
+
+Set to true to output docker-compose logs for running services.
+
+```
+steps:
+  - command: path/to/script.sh
+    plugins:
+      - 'albertywu/run-docker-compose':
+        # Required properties
+        logs: true
+```
+
 ### `verbose` (optional)
 
 Sets `docker-compose` to run with `--verbose`

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -2,4 +2,4 @@
 
 echo "[Run Docker Compose Plugin] - Skipping git checkout"
 
-git clean -ffxdq
+git clean -ffxdq || true

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -4,7 +4,9 @@ set -ex
 
 COMPOSE_FILE=$BUILDKITE_PLUGIN_RUN_DOCKER_COMPOSE_COMPOSE_FILE
 
-docker-compose -f $COMPOSE_FILE logs --tail="all"
+if [ "$BUILDKITE_PLUGIN_RUN_DOCKER_COMPOSE_LOGS" == "true" ]; then
+  docker-compose -f $COMPOSE_FILE logs --tail="all"
+fi
 
 # Try to spin down services
 docker-compose -f $COMPOSE_FILE kill || true

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -4,6 +4,8 @@ set -ex
 
 COMPOSE_FILE=$BUILDKITE_PLUGIN_RUN_DOCKER_COMPOSE_COMPOSE_FILE
 
+docker-compose -f $COMPOSE_FILE logs --tail="all"
+
 # Try to spin down services
 docker-compose -f $COMPOSE_FILE kill || true
 docker-compose -f $COMPOSE_FILE down || true

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,6 +18,8 @@ configuration:
       type: string
     verbose:
       type: boolean
+    logs:
+      type: boolean
   required:
     - image
     - package


### PR DESCRIPTION
This is necessary to see what's happening when running additional docker-compose services.